### PR TITLE
Bump user-events dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "@sheerun/mutationobserver-shim": "^0.3.3",
     "@testing-library/jest-dom": "^5.11.3",
     "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
+    "@testing-library/user-event": "^13.0.0",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.2",
     "@types/react": "^16.8.0",


### PR DESCRIPTION
Reason: for documentation purposes. The test requires `userEvent.keyboard` in order to operate. This was [introduced in userEvent v13](https://github.com/testing-library/user-event/releases/tag/v13.0.0).

This example code works solely because it's pulling the correct version of userEvent from the base react-beautiful-dnd-test-utils root. But if you're a user like me with an older version, trying to debug why my tests are failing when I have the same exact package.json versions as this example project... it would be helpful for these package versions to reflect the actual necessary version in order for it to run.